### PR TITLE
fix "too many values to unpack", remove cpu timing

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -54,11 +54,11 @@ if __name__ == '__main__':
         Xt_gpu = Xt_cpu.cuda()
         
         # t = time()
-        auc_cpu_score, auc_cpu_ass, _ = auction_lap(Xt_cpu, eps=None) # Score is accurate to within n * eps
+        # auc_cpu_score, auc_cpu_ass, _ = auction_lap(Xt_cpu, eps=None) # Score is accurate to within n * eps
         # auc_cpu_time = time() - t
         
         t = time()
-        auc_gpu_score, auc_gpu_ass = auction_lap(Xt_gpu, eps=args.eps) # Score is accurate to within n * eps
+        auc_gpu_score, auc_gpu_ass, _ = auction_lap(Xt_gpu, eps=args.eps) # Score is accurate to within n * eps
         auc_gpu_time = time() - t
         
         print(json.dumps({


### PR DESCRIPTION
`auction_lap` returns three values instead of two.

The CPU time wasn't used in the benchmark so I removed it.